### PR TITLE
Update rulesets submodule pointer

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,3 @@
 [submodule "lib/iati-rulesets"]
 	path = lib/iati-rulesets
-	url = https://github.com/IATI/IATI-Rulesets.git
-	branch = master
+	url = https://github.com/data4development/IATI-Rulesets.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "lib/iati-rulesets"]
 	path = lib/iati-rulesets
-	url = https://github.com/data4development/IATI-Rulesets.git
+	url = https://github.com/IATI/IATI-Rulesets.git
+	branch = master


### PR DESCRIPTION
## Summary
The validator uses a submodule for the lib/iati-rulesets directory. 

Currently that submodule is pointing to the "old" [data4development/IATI-Rulesets](https://github.com/data4development/IATI-Rulesets.git) repo.

This is now updated to the source of truth IATI managed repo [IATI/IATI-Rulesets](https://github.com/IATI/IATI-Rulesets.git) (master branch)

