### PR TITLE
Fix fatal error when namespace isn't declared in XML

### DIFF
--- a/build-engine.xml
+++ b/build-engine.xml
@@ -103,8 +103,8 @@
   <target name="run_testsuites" depends="xml-check, rules, test-context, test-json, test-validator"/>
   
   <target name="test" description="Run test suites">
-    <symlink action="delete" link="/work/space"/>
-    <copy todir="/work/space">
+    <delete file="/work/space" followsymlinks="false" removenotfollowedsymlinks="true" />
+    <copy todir="/workspace">
       <fileset dir="/home/testspace"/>
     </copy>
     <antcall target="run_testsuites"/>    

--- a/tests/non-iati-files.xspec
+++ b/tests/non-iati-files.xspec
@@ -36,6 +36,12 @@
       <x:expect label="It should return root element not-an-xml-file" test="boolean(/not-an-xml-file)"/>
       <x:expect label="It should produce message 0.1.1" test="boolean(//me:feedback[@id='0.1.1'])"/>
     </x:scenario>    
+
+    <x:scenario label="If the file is not recoverable as IATI, due to a namespace error">
+      <x:context href="/work/space/dest/iati-broken-ns.feedback.xml"/>
+      <x:expect label="It should return root element not-an-xml-file" test="boolean(/not-an-xml-file)"/>
+      <x:expect label="It should produce message 0.1.1" test="boolean(//me:feedback[@id='0.1.1'])"/>
+    </x:scenario> 
   </x:scenario>      
   
   <x:scenario label="Non-IATI files: not XML at all">

--- a/testspace/input/iati-broken-ns.xml
+++ b/testspace/input/iati-broken-ns.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<iati-activities undef-namespace:version="2.03">
+  <iati-activity>
+    <iati-identifier></iati-identifier>
+    <reporting-org ref="" type="">
+      <narrative></narrative>
+    </reporting-org>
+    <title>
+      <narrative>Activity with a closing tag error</narrative>
+    </title>
+    <description>
+      <narrative></narrative>
+    </description>
+    <participating-org role="">
+    </participating-org>
+    <activity-status code="">
+    </activity-status>
+    <activity-date type="" iso-date="2018-01-01">
+    </activity-date>
+  </iati-activity>
+</iati-activities>

--- a/xml-check
+++ b/xml-check
@@ -43,76 +43,88 @@ find . -name "${FILEMASK}*" -type f -print | while read FILE; do
     rm "$WORKSPACE/tmp/xmltest/$NAME"
   fi
 
+  NSERROR=''
+  if grep -q "namespace error" "$WORKSPACE/tmp/xmltestlog/$NAME"; then
+    NSERROR=true
+  else
+    NSERROR=false
+  fi
+
+  ISIATI=''
   cd $WORKSPACE/$SRCDIR
   XMLROOT=`xmllint --xpath "local-name(/*)" "$NAME" 2> /dev/null`
   XMLATTR=`xmllint --xpath "string(/*/@version)" "$NAME" 2> /dev/null`
-  
   if [[ "$XMLROOT." == "iati-activities." || "$XMLROOT." == "iati-organisations." ]]; then
-    if [[ $XMLATTR. =~ 1\.0[1-5]\. || $XMLATTR. =~ 2\.0[1-3]\. ]]; then
-      VERSION=$XMLATTR
-    elif [[ $XMLATTR. =~ 1\..* ]]; then
-      VERSION=1.05
-    else
-      VERSION=2.03
-    fi
-    
-    if xmllint --noout --schema /home/lib/iati-rulesets/lib/schemata/$VERSION/$XMLROOT-schema.xsd "$NAME" 2> "$WORKSPACE/tmp/xmlschemalog/$NAME"; then
-      rm "$WORKSPACE/tmp/xmlschemalog/$NAME"
-      if [ -s "$WORKSPACE/tmp/xmltestlog/$NAME" ]; then
-        echo '<recovered-iati-file/>' > "$WORKSPACE/tmp/iatifeedback/$NAME"
-        echo "$PREFIX $MD5: recovered-iati-file"
-        
-        if [[ "$API" != "none" ]]; then
-          APIDATA="{\"md5\": \"$MD5\", \"file-type\": \"recovered-iati-file\", \"iati-version\": \"$VERSION\"}"
+    ISIATI=true
+  else  
+    ISIATI=false  
+  fi
 
-          curl -sS -X POST --header 'Content-Type: application/json' --header 'Accept: application/json' \
-            -d "$APIDATA" \
-            "$API/$DATASETS/update?where=%7B%22md5%22%3A%22$MD5%22%7D"
-        fi        
+  if [[ $NSERROR == false && $ISIATI == true ]]; then
+      if [[ $XMLATTR. =~ 1\.0[1-5]\. || $XMLATTR. =~ 2\.0[1-3]\. ]]; then
+        VERSION=$XMLATTR
+      elif [[ $XMLATTR. =~ 1\..* ]]; then
+        VERSION=1.05
       else
-        echo '<iati-file/>' > "$WORKSPACE/tmp/iatifeedback/$NAME"
-        echo "$PREFIX $MD5: iati-file"
-        
-        if [[ "$API" != "none" ]]; then
-          APIDATA="{\"md5\": \"$MD5\", \"file-type\": \"iati-file\", \"iati-version\": \"$VERSION\"}"
-
-          curl -sS -X POST --header 'Content-Type: application/json' --header 'Accept: application/json' \
-            -d "$APIDATA" \
-            "$API/$DATASETS/update?where=%7B%22md5%22%3A%22$MD5%22%7D"
-        fi        
+        VERSION=2.03
       fi
-    else
-      LL=`cat "$WORKSPACE/tmp/xmlschemalog/$NAME" | wc -l`
-      if [[ $LL -gt 4000 ]]; then
-        echo "$PREFIX $MD5: limiting schema validation log of $LL lines to $VALLOGL lines"
-        sed -i "2001,$((LL-$VALLOGS))c...skipped $((LL-$VALLOGL)) lines..." "$WORKSPACE/tmp/xmlschemalog/$NAME" 
-      fi
+      
+      if xmllint --noout --schema /home/lib/iati-rulesets/lib/schemata/$VERSION/$XMLROOT-schema.xsd "$NAME" 2> "$WORKSPACE/tmp/xmlschemalog/$NAME"; then
+        rm "$WORKSPACE/tmp/xmlschemalog/$NAME"
+        if [ -s "$WORKSPACE/tmp/xmltestlog/$NAME" ]; then
+          echo '<recovered-iati-file/>' > "$WORKSPACE/tmp/iatifeedback/$NAME"
+          echo "$PREFIX $MD5: recovered-iati-file"
+          
+          if [[ "$API" != "none" ]]; then
+            APIDATA="{\"md5\": \"$MD5\", \"file-type\": \"recovered-iati-file\", \"iati-version\": \"$VERSION\"}"
 
-      if [ -s "$WORKSPACE/tmp/xmltestlog/$NAME" ]; then
-        echo '<recovered-iati-file-with-schema-errors/>' > "$WORKSPACE/tmp/iatifeedback/$NAME"
-        echo "$PREFIX $MD5: recovered-iati-file-with-schema-errors"
+            curl -sS -X POST --header 'Content-Type: application/json' --header 'Accept: application/json' \
+              -d "$APIDATA" \
+              "$API/$DATASETS/update?where=%7B%22md5%22%3A%22$MD5%22%7D"
+          fi        
+        else
+          echo '<iati-file/>' > "$WORKSPACE/tmp/iatifeedback/$NAME"
+          echo "$PREFIX $MD5: iati-file"
+          
+          if [[ "$API" != "none" ]]; then
+            APIDATA="{\"md5\": \"$MD5\", \"file-type\": \"iati-file\", \"iati-version\": \"$VERSION\"}"
 
-        if [[ "$API" != "none" ]]; then
-          APIDATA="{\"md5\": \"$MD5\", \"file-type\": \"recovered-iati-file-with-schema-errors\", \"iati-version\": \"$VERSION\"}"
-
-          curl -sS -X POST --header 'Content-Type: application/json' --header 'Accept: application/json' \
-            -d "$APIDATA" \
-            "$API/$DATASETS/update?where=%7B%22md5%22%3A%22$MD5%22%7D"
-        fi        
-      else
-        echo '<iati-file-with-schema-errors/>' > "$WORKSPACE/tmp/iatifeedback/$NAME"
-        echo "$PREFIX $MD5: iati-file-with-schema-errors"
-
-        if [[ "$API" != "none" ]]; then
-          APIDATA="{\"md5\": \"$MD5\", \"file-type\": \"iati-file-with-schema-errors\", \"iati-version\": \"$VERSION\"}"
-
-          curl -sS -X POST --header 'Content-Type: application/json' --header 'Accept: application/json' \
-            -d "$APIDATA" \
-            "$API/$DATASETS/update?where=%7B%22md5%22%3A%22$MD5%22%7D"
+            curl -sS -X POST --header 'Content-Type: application/json' --header 'Accept: application/json' \
+              -d "$APIDATA" \
+              "$API/$DATASETS/update?where=%7B%22md5%22%3A%22$MD5%22%7D"
+          fi        
         fi
-      fi       
-    fi
-    
+      else
+        LL=`cat "$WORKSPACE/tmp/xmlschemalog/$NAME" | wc -l`
+        if [[ $LL -gt 4000 ]]; then
+          echo "$PREFIX $MD5: limiting schema validation log of $LL lines to $VALLOGL lines"
+          sed -i "2001,$((LL-$VALLOGS))c...skipped $((LL-$VALLOGL)) lines..." "$WORKSPACE/tmp/xmlschemalog/$NAME" 
+        fi
+
+        if [ -s "$WORKSPACE/tmp/xmltestlog/$NAME" ]; then
+          echo '<recovered-iati-file-with-schema-errors/>' > "$WORKSPACE/tmp/iatifeedback/$NAME"
+          echo "$PREFIX $MD5: recovered-iati-file-with-schema-errors"
+
+          if [[ "$API" != "none" ]]; then
+            APIDATA="{\"md5\": \"$MD5\", \"file-type\": \"recovered-iati-file-with-schema-errors\", \"iati-version\": \"$VERSION\"}"
+
+            curl -sS -X POST --header 'Content-Type: application/json' --header 'Accept: application/json' \
+              -d "$APIDATA" \
+              "$API/$DATASETS/update?where=%7B%22md5%22%3A%22$MD5%22%7D"
+          fi        
+        else
+          echo '<iati-file-with-schema-errors/>' > "$WORKSPACE/tmp/iatifeedback/$NAME"
+          echo "$PREFIX $MD5: iati-file-with-schema-errors"
+
+          if [[ "$API" != "none" ]]; then
+            APIDATA="{\"md5\": \"$MD5\", \"file-type\": \"iati-file-with-schema-errors\", \"iati-version\": \"$VERSION\"}"
+
+            curl -sS -X POST --header 'Content-Type: application/json' --header 'Accept: application/json' \
+              -d "$APIDATA" \
+              "$API/$DATASETS/update?where=%7B%22md5%22%3A%22$MD5%22%7D"
+          fi
+        fi       
+      fi
   
   elif [ -s "$WORKSPACE/tmp/xmltestlog/$NAME" ]; then
      


### PR DESCRIPTION
## Previously
If a file used a custom namespace without declaring it, the file would cause a fatal error in the Saxon parser
```
[xslt] Caught an error during transformation: net.sf.saxon.trans.XPathException: org.xml.sax.SAXParseException; systemId: file:/work/space/src/e431887d-d7b1-4539-b0d3-97db96084690.xml; lineNumber: 3; columnNumber: 181; The prefix "iati-extra" for attribute "iati-extra:version" associated with an element type "iati-activity" is not bound.
```

This would cause the validator to stall processing uploaded files as it would continuously re-try this file.

## Now
A file using a custom namespace without a declaration will be treated as malformed XML and will return a response with a 'not-an-xml-file' error. 

## Testing
A test has been added in `tests/non-iati-files.xspec` which is now passing. 

To run tests:
Build image - `docker build -t my_validator:latest .`
Run tests - `docker run --rm my_validator test`
